### PR TITLE
fix: FirstLineContainsHeader type from int to bool, update respective test cases

### DIFF
--- a/crowdin/model/translation_memory.go
+++ b/crowdin/model/translation_memory.go
@@ -157,7 +157,7 @@ type TranslationMemoryImport struct {
 	Attributes struct {
 		TMID                    int            `json:"tmId"`
 		StorageID               int            `json:"storageId"`
-		FirstLineContainsHeader int            `json:"firstLineContainsHeader"`
+		FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 		Scheme                  map[string]int `json:"scheme"`
 	} `json:"attributes"`
 	CreatedAt  string `json:"createdAt"`

--- a/crowdin/translation_memory_test.go
+++ b/crowdin/translation_memory_test.go
@@ -449,7 +449,7 @@ func TestTranslationMemoryService_ImportTM(t *testing.T) {
 				"attributes": {
 					"tmId": 10,
 					"storageId": 28,
-					"firstLineContainsHeader": 10,
+					"firstLineContainsHeader": true,
 					"scheme": {
 						"en": 0,
 						"de": 2
@@ -484,12 +484,12 @@ func TestTranslationMemoryService_ImportTM(t *testing.T) {
 		Attributes: struct {
 			TMID                    int            `json:"tmId"`
 			StorageID               int            `json:"storageId"`
-			FirstLineContainsHeader int            `json:"firstLineContainsHeader"`
+			FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 			Scheme                  map[string]int `json:"scheme"`
 		}{
 			TMID:                    10,
 			StorageID:               28,
-			FirstLineContainsHeader: 10,
+			FirstLineContainsHeader: true,
 			Scheme: map[string]int{
 				"en": 0,
 				"de": 2,
@@ -522,7 +522,7 @@ func TestTranslationMemoryService_CheckTMImportStatus(t *testing.T) {
 				"attributes": {
 					"tmId": 10,
 					"storageId": 28,
-					"firstLineContainsHeader": 10,
+					"firstLineContainsHeader": true,
 					"scheme": {
 					"en": 0,
 					"de": 2
@@ -547,12 +547,12 @@ func TestTranslationMemoryService_CheckTMImportStatus(t *testing.T) {
 		Attributes: struct {
 			TMID                    int            `json:"tmId"`
 			StorageID               int            `json:"storageId"`
-			FirstLineContainsHeader int            `json:"firstLineContainsHeader"`
+			FirstLineContainsHeader bool           `json:"firstLineContainsHeader"`
 			Scheme                  map[string]int `json:"scheme"`
 		}{
 			TMID:                    10,
 			StorageID:               28,
-			FirstLineContainsHeader: 10,
+			FirstLineContainsHeader: true,
 			Scheme: map[string]int{
 				"en": 0,
 				"de": 2,


### PR DESCRIPTION
Fixes #61 

Changes made in this PR:
1. change type of `FirstLineContainsHeader` from `int` to `bool`
2. update respective testcases ( `TestTranslationMemoryService_ImportTM` and `TestTranslationMemoryService_CheckTMImportStatus` ) to use and expect `bool` instead of `int`