### PR TITLE
feat: add new `updateOption` parameter

### DIFF
--- a/crowdin/model/source_strings.go
+++ b/crowdin/model/source_strings.go
@@ -249,6 +249,10 @@ type SourceStringsUploadRequest struct {
 	CleanupMode *bool `json:"cleanupMode,omitempty"`
 	// Options for importing strings.
 	ImportOptions *SourceStringsImportOptions `json:"importOptions,omitempty"`
+	// Option for updating strings. Default: "clear_translations_and_approvals".
+	// Enum: "clear_translations_and_approvals" "keep_translations" "keep_translations_and_approvals"
+	// Must be used together with updateStrings = true
+	UpdateOption string `json:"updateOption,omitempty"`
 }
 
 // SourceStringsImportOptions defines the options for importing strings.

--- a/crowdin/model/source_strings.go
+++ b/crowdin/model/source_strings.go
@@ -279,6 +279,9 @@ func (o *SourceStringsUploadRequest) Validate() error {
 	if o.BranchID == 0 {
 		return errors.New("branchId is required")
 	}
+	if o.UpdateOption != "" && !(*o.UpdateStrings) {
+		return errors.New("updateStrings must be set to true to use updateOption")
+	}
 
 	return nil
 }

--- a/crowdin/model/source_strings_test.go
+++ b/crowdin/model/source_strings_test.go
@@ -186,11 +186,27 @@ func TestSourceStringsUploadRequestValidate(t *testing.T) {
 			err:  "branchId is required",
 		},
 		{
+			name: "invalid request",
+			req: &SourceStringsUploadRequest{StorageID: 1, BranchID: 1, Type: "xlsx", ParserVersion: 1,
+				LabelIDs: []int{1, 2, 3}, UpdateStrings: toPtr(false), CleanupMode: toPtr(false),
+				ImportOptions: &SourceStringsImportOptions{FirstLineContainsHeader: toPtr(true),
+					ImportTranslations: toPtr(true), Scheme: map[string]int{"key": 0}}, UpdateOption: "clear_translations_and_approvals"},
+			err: "updateStrings must be set to true to use updateOption",
+		},
+		{
 			name: "valid request",
 			req: &SourceStringsUploadRequest{StorageID: 1, BranchID: 1, Type: "xlsx", ParserVersion: 1,
 				LabelIDs: []int{1, 2, 3}, UpdateStrings: toPtr(false), CleanupMode: toPtr(false),
 				ImportOptions: &SourceStringsImportOptions{FirstLineContainsHeader: toPtr(true),
 					ImportTranslations: toPtr(true), Scheme: map[string]int{"key": 0}}},
+			valid: true,
+		},
+		{
+			name: "valid request 2",
+			req: &SourceStringsUploadRequest{StorageID: 1, BranchID: 1, Type: "xlsx", ParserVersion: 1,
+				LabelIDs: []int{1, 2, 3}, UpdateStrings: toPtr(true), CleanupMode: toPtr(false),
+				ImportOptions: &SourceStringsImportOptions{FirstLineContainsHeader: toPtr(true),
+					ImportTranslations: toPtr(true), Scheme: map[string]int{"key": 0}}, UpdateOption: "clear_translations_and_approvals"},
 			valid: true,
 		},
 	}

--- a/crowdin/source_strings_test.go
+++ b/crowdin/source_strings_test.go
@@ -889,6 +889,7 @@ func TestSourceStringsService_UploadWithValidationError(t *testing.T) {
 		{"nil request", nil, "request cannot be nil"},
 		{"empty storageId", &model.SourceStringsUploadRequest{BranchID: 34}, "storageId is required"},
 		{"empty branchId", &model.SourceStringsUploadRequest{StorageID: 61}, "branchId is required"},
+		{"misconfigured updateStrings for non-empty updateOption", &model.SourceStringsUploadRequest{BranchID: 34, StorageID: 61, UpdateStrings: ToPtr(false), UpdateOption: "clear_translations_and_approvals"}, "updateStrings must be set to true to use updateOption"},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
Resolves #60 


Changes made in this PR: 
1. add new field `UpdateOption` in `SourceStringsUploadRequest` according to https://support.crowdin.com/developer/api/v2/string-based/#tag/Source-Strings/operation/api.projects.strings.uploads.post. Also added comment for the field outlining the default value and enum values
2. add validation for `UpdateOption`. To use this field, the field `UpdateStrings` must be set to `true` as a prerequisite
3. add testcases for invalid and valid cases


