### PR TITLE
feat: add `stringIds` param support

### DIFF
--- a/crowdin/model/screenshot.go
+++ b/crowdin/model/screenshot.go
@@ -101,6 +101,9 @@ func (o *ScreenshotListOptions) Values() (url.Values, bool) {
 	if o.StringID > 0 { // TODO: StringID is deprecated
 		v.Add("stringId", fmt.Sprintf("%d", o.StringID))
 	}
+	if len(o.StringIDs) > 0 {
+		v.Add("stringIds", JoinSlice(o.StringIDs))
+	}
 	if len(o.LabelIDs) > 0 {
 		v.Add("labelIds", JoinSlice(o.LabelIDs))
 	}

--- a/crowdin/model/screenshot.go
+++ b/crowdin/model/screenshot.go
@@ -98,7 +98,7 @@ func (o *ScreenshotListOptions) Values() (url.Values, bool) {
 	if len(o.OrderBy) > 0 {
 		v.Add("orderBy", o.OrderBy)
 	}
-	if o.StringID > 0 {
+	if o.StringID > 0 { // TODO: StringID is deprecated
 		v.Add("stringId", fmt.Sprintf("%d", o.StringID))
 	}
 	if len(o.LabelIDs) > 0 {

--- a/crowdin/model/screenshot.go
+++ b/crowdin/model/screenshot.go
@@ -114,6 +114,14 @@ func (o *ScreenshotListOptions) Values() (url.Values, bool) {
 	return v, len(v) > 0
 }
 
+func (r *ScreenshotListOptions) Validate() error {
+	if r.StringID > 0 && len(r.StringIDs) > 0 {
+		return errors.New("stringId and stringIds cannot be used in the same request")
+	}
+
+	return nil
+}
+
 // ScreenshotAddRequest defines the structure of a request
 // to add a screenshot.
 type ScreenshotAddRequest struct {

--- a/crowdin/model/screenshot.go
+++ b/crowdin/model/screenshot.go
@@ -71,7 +71,11 @@ type ScreenshotListOptions struct {
 	// Example: orderBy=createdAt desc,name,tagsCount
 	OrderBy string `json:"orderBy,omitempty"`
 	// String Identifier.
-	StringID int `json:"stringId,omitempty"`
+	StringID int `json:"stringId,omitempty"` // Deprecated. Use StringIDs instead.
+	// String Identifiers.
+	// Example: stringIds=1,2,3,4,5
+	// Note: Cannot be used with stringId in the same request.
+	StringIDs []string `json:"stringIds,omitempty"`
 	// Label Identifiers.
 	// Example: labelIds=1,2,3
 	LabelIDs []string `json:"labelIds,omitempty"`

--- a/crowdin/model/screenshot.go
+++ b/crowdin/model/screenshot.go
@@ -114,8 +114,8 @@ func (o *ScreenshotListOptions) Values() (url.Values, bool) {
 	return v, len(v) > 0
 }
 
-func (r *ScreenshotListOptions) Validate() error {
-	if r.StringID > 0 && len(r.StringIDs) > 0 {
+func (o *ScreenshotListOptions) Validate() error {
+	if o.StringID > 0 && len(o.StringIDs) > 0 {
 		return errors.New("stringId and stringIds cannot be used in the same request")
 	}
 

--- a/crowdin/model/screenshot_test.go
+++ b/crowdin/model/screenshot_test.go
@@ -22,7 +22,7 @@ func TestScreenshotListOptionsValues(t *testing.T) {
 		},
 		{
 			name: "with all options",
-			opts: &ScreenshotListOptions{OrderBy: "createdAt desc,name,tagsCount", StringID: 1,
+			opts: &ScreenshotListOptions{OrderBy: "createdAt desc,name,tagsCount", StringID: 1, // TODO: StringID is deprecated
 				LabelIDs: []string{"1", "2", "3"}, ExcludeLabelIDs: []string{"4", "5", "6"},
 				ListOptions: ListOptions{Offset: 1, Limit: 10}},
 			out: "excludeLabelIds=4%2C5%2C6&labelIds=1%2C2%2C3&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2CtagsCount&stringId=1",

--- a/crowdin/model/screenshot_test.go
+++ b/crowdin/model/screenshot_test.go
@@ -27,6 +27,13 @@ func TestScreenshotListOptionsValues(t *testing.T) {
 				ListOptions: ListOptions{Offset: 1, Limit: 10}},
 			out: "excludeLabelIds=4%2C5%2C6&labelIds=1%2C2%2C3&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2CtagsCount&stringId=1",
 		},
+		{
+			name: "with all options",
+			opts: &ScreenshotListOptions{OrderBy: "createdAt desc,name,tagsCount", StringIDs: []string{"1", "2", "3"},
+				LabelIDs: []string{"1", "2", "3"}, ExcludeLabelIDs: []string{"4", "5", "6"},
+				ListOptions: ListOptions{Offset: 1, Limit: 10}},
+			out: "excludeLabelIds=4%2C5%2C6&labelIds=1%2C2%2C3&limit=10&offset=1&orderBy=createdAt+desc%2Cname%2CtagsCount&stringIds=1%2C2%2C3",
+		},
 	}
 
 	for _, tt := range tests {

--- a/crowdin/model/screenshot_test.go
+++ b/crowdin/model/screenshot_test.go
@@ -50,6 +50,34 @@ func TestScreenshotListOptionsValues(t *testing.T) {
 	}
 }
 
+func TestScreenshotListOptionsValidate(t *testing.T) {
+	// my func, to validate
+	tests := []struct {
+		name  string
+		req   *ScreenshotListOptions
+		err   string
+		valid bool
+	}{
+		{
+			name: "invalid case - using both stringId and stringIds in the same request",
+			req: &ScreenshotListOptions{OrderBy: "createdAt desc,name,tagsCount", StringID: 1, StringIDs: []string{"1", "2", "3"}, // TODO: StringID is deprecated
+				LabelIDs: []string{"1", "2", "3"}, ExcludeLabelIDs: []string{"4", "5", "6"},
+				ListOptions: ListOptions{Offset: 1, Limit: 10}},
+			err: "stringId and stringIds cannot be used in the same request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.req.Validate(); tt.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.err)
+			}
+		})
+	}
+}
+
 func TestScreenshotAddRequestValidate(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/crowdin/model/screenshot_test.go
+++ b/crowdin/model/screenshot_test.go
@@ -51,7 +51,6 @@ func TestScreenshotListOptionsValues(t *testing.T) {
 }
 
 func TestScreenshotListOptionsValidate(t *testing.T) {
-	// my func, to validate
 	tests := []struct {
 		name  string
 		req   *ScreenshotListOptions

--- a/crowdin/screenshots_test.go
+++ b/crowdin/screenshots_test.go
@@ -136,7 +136,7 @@ func TestScreenshotsService_ListScreenshot(t *testing.T) {
 			name: "all options",
 			opts: &model.ScreenshotListOptions{
 				OrderBy:         "createdAt desc,name,tagsCount",
-				StringID:        1,
+				StringID:        1, // TODO: StringID is deprecated
 				LabelIDs:        []string{"1", "2", "3"},
 				ExcludeLabelIDs: []string{"1", "2", "3"},
 				ListOptions: model.ListOptions{


### PR DESCRIPTION
Resolves #56 

Changes made in this PR:
1. add `TODO: StringID is deprecated` comments for the deprecated field `stringId`
2. add new field `StringIDs []string `json:"stringIds,omitempty"`` for `ScreenshotListOptions`
3. add `JoinSlice` logic for stringIds. 
4. created Validate() to make sure stringId and stringIds can't be used in the same request ( ref: https://support.crowdin.com/developer/api/v2/#tag/Screenshots/operation/api.projects.screenshots.getMany )
5. add updated case for values
6. created `TestScreenshotListOptionsValidate`