### PR TITLE
feat: add `defaultTmId` and `defaultGlossaryId` support

### DIFF
--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -243,6 +243,13 @@ type ProjectsAddRequest struct {
 	TMContextType  string                 `json:"tmContextType,omitempty"`
 	TMPreTranslate *ProjectTMPreTranslate `json:"tmPreTranslate,omitempty"`
 	MTPreTranslate *ProjectMTPreTranslate `json:"mtPreTranslate,omitempty"`
+	// FIXME: missing fields for aiPreTranslate and assistActionAiPromptId ( TODO: create new issue )
+	// Translation Memory ID.
+	// Default: null
+	DefaultTMID int `json:"defaultTmId,omitempty"`
+	// Glossary ID.
+	// Default: null
+	DefaultGlossaryID int `json:"defaultGlossaryId,omitempty"`
 	// Context and max.length added in Crowdin will be visible in the downloaded files.
 	SaveMetaInfoInSource *bool `json:"saveMetaInfoInSource,omitempty"`
 	// Defines the project type. Use 0 for a file-based project and 1 for a string-based project.

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -253,11 +253,12 @@ type ProjectsAddRequest struct {
 	// segmentContext - searching by context.
 	// auto - context search for key-value formats and segment search for others.
 	// prevAndNextSegment - search by previous and next segment.
-	TMContextType          string                 `json:"tmContextType,omitempty"`
-	TMPreTranslate         *ProjectTMPreTranslate `json:"tmPreTranslate,omitempty"`
-	MTPreTranslate         *ProjectMTPreTranslate `json:"mtPreTranslate,omitempty"`
-	AiPreTranslate         *ProjectAiPreTranslate `json:"aiPreTranslate,omitempty"`
-	AssistActionAiPromptID int                    `json:"assistActionAiPromptId,omitempty"`
+	TMContextType  string                 `json:"tmContextType,omitempty"`
+	TMPreTranslate *ProjectTMPreTranslate `json:"tmPreTranslate,omitempty"`
+	MTPreTranslate *ProjectMTPreTranslate `json:"mtPreTranslate,omitempty"`
+	AiPreTranslate *ProjectAiPreTranslate `json:"aiPreTranslate,omitempty"`
+	// AI Prompt ID to be used as prompt for Assist action
+	AssistActionAiPromptID int `json:"assistActionAiPromptId,omitempty"`
 	// Translation Memory ID.
 	// Default: null
 	DefaultTMID int `json:"defaultTmId,omitempty"`

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -257,7 +257,7 @@ type ProjectsAddRequest struct {
 	TMPreTranslate         *ProjectTMPreTranslate `json:"tmPreTranslate,omitempty"`
 	MTPreTranslate         *ProjectMTPreTranslate `json:"mtPreTranslate,omitempty"`
 	AiPreTranslate         *ProjectAiPreTranslate `json:"aiPreTranslate,omitempty"`
-	AssistActionAiPromptId int                    `json:"assistActionAiPromptId,omitempty"`
+	AssistActionAiPromptID int                    `json:"assistActionAiPromptId,omitempty"`
 	// Translation Memory ID.
 	// Default: null
 	DefaultTMID int `json:"defaultTmId,omitempty"`

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -107,11 +107,24 @@ type (
 		MTs     []ProjectMTs `json:"mts,omitempty"`
 	}
 
+	ProjectAiPreTranslate struct {
+		Enabled   *bool             `json:"enabled,omitempty"`
+		AiPrompts []ProjectAiPrompt `json:"aiPrompts,omitempty"`
+	}
+
 	ProjectMTs struct {
 		MTID int `json:"mtId,omitempty"`
 		// Specify an array of languageIds to use specific languages, or use the string all
 		// to include all supported languages.
 		// Retrieve languageIds via the `List Supported Languages` endpoint
+		LanguageIDs []string `json:"languageIds,omitempty"`
+	}
+
+	ProjectAiPrompt struct {
+		AiPromptID int `json:"aiPromptId,omitempty"`
+		// Specify an array of languageIds to use specific languages, or use the string all
+		// to include all supported languages.
+		// Retrieve languageIds via the List Supported Languages endpoint
 		LanguageIDs []string `json:"languageIds,omitempty"`
 	}
 )

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -61,8 +61,8 @@ type (
 		LanguageMapping                 map[string]LanguageMapping `json:"languageMapping,omitempty"`
 		DelayedWorkflowStart            bool                       `json:"delayedTranslations,omitempty"`
 		NotificationSettings            *NotificationSettings      `json:"notificationSettings,omitempty"`
-		DefaultTMID                     int                        `json:"defaultTmId,omitempty"`       // FIXME: shouldn't it be *int? looks like according to the API doc, this field is nullable
-		DefaultGlossaryID               int                        `json:"defaultGlossaryId,omitempty"` // FIXME: shouldn't it be *int?
+		DefaultTMID                     int                        `json:"defaultTmId,omitempty"`
+		DefaultGlossaryID               int                        `json:"defaultGlossaryId,omitempty"`
 		AssignedTMs                     map[int]map[string]int     `json:"assignedTms,omitempty"`
 		AssignedGlossaries              []int                      `json:"assignedGlossaries,omitempty"`
 		TMPenalties                     any                        `json:"tmPenalties,omitempty"`

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -253,10 +253,11 @@ type ProjectsAddRequest struct {
 	// segmentContext - searching by context.
 	// auto - context search for key-value formats and segment search for others.
 	// prevAndNextSegment - search by previous and next segment.
-	TMContextType  string                 `json:"tmContextType,omitempty"`
-	TMPreTranslate *ProjectTMPreTranslate `json:"tmPreTranslate,omitempty"`
-	MTPreTranslate *ProjectMTPreTranslate `json:"mtPreTranslate,omitempty"`
-	// FIXME: missing fields for aiPreTranslate and assistActionAiPromptId ( TODO: create new issue )
+	TMContextType          string                 `json:"tmContextType,omitempty"`
+	TMPreTranslate         *ProjectTMPreTranslate `json:"tmPreTranslate,omitempty"`
+	MTPreTranslate         *ProjectMTPreTranslate `json:"mtPreTranslate,omitempty"`
+	AiPreTranslate         *ProjectAiPreTranslate `json:"aiPreTranslate,omitempty"`
+	AssistActionAiPromptId int                    `json:"assistActionAiPromptId,omitempty"`
 	// Translation Memory ID.
 	// Default: null
 	DefaultTMID int `json:"defaultTmId,omitempty"`

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -61,8 +61,8 @@ type (
 		LanguageMapping                 map[string]LanguageMapping `json:"languageMapping,omitempty"`
 		DelayedWorkflowStart            bool                       `json:"delayedTranslations,omitempty"`
 		NotificationSettings            *NotificationSettings      `json:"notificationSettings,omitempty"`
-		DefaultTMID                     int                        `json:"defaultTmId,omitempty"`
-		DefaultGlossaryID               int                        `json:"defaultGlossaryId,omitempty"`
+		DefaultTMID                     int                        `json:"defaultTmId,omitempty"`       // FIXME: shouldn't it be *int? looks like according to the API doc, this field is nullable
+		DefaultGlossaryID               int                        `json:"defaultGlossaryId,omitempty"` // FIXME: shouldn't it be *int?
 		AssignedTMs                     map[int]map[string]int     `json:"assignedTms,omitempty"`
 		AssignedGlossaries              []int                      `json:"assignedGlossaries,omitempty"`
 		TMPenalties                     any                        `json:"tmPenalties,omitempty"`

--- a/crowdin/projects_test.go
+++ b/crowdin/projects_test.go
@@ -1230,7 +1230,9 @@ func TestProjectsService_Edit(t *testing.T) {
 		fmt.Fprint(w, `{
 			"data": {
 				"id": 8,
-				"name": "New Name"
+				"name": "New Name",
+				"defaultTmId": 2,
+				"defaultGlossaryId": 2
 			}
 		}`)
 	})
@@ -1246,8 +1248,10 @@ func TestProjectsService_Edit(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedProject := &model.Project{
-		ID:   8,
-		Name: "New Name",
+		ID:                8,
+		Name:              "New Name",
+		DefaultTMID:       2,
+		DefaultGlossaryID: 2,
 	}
 	assert.Equal(t, expectedProject, project)
 	assert.NotNil(t, resp)

--- a/crowdin/projects_test.go
+++ b/crowdin/projects_test.go
@@ -1037,6 +1037,7 @@ func TestProjectsService_Add(t *testing.T) {
 				},
 			},
 		},
+		AssistActionAiPromptID:        1,
 		DefaultTMID:                   1,
 		DefaultGlossaryID:             1,
 		SaveMetaInfoInSource:          ToPtr(true),
@@ -1156,6 +1157,7 @@ func TestProjectsService_Add(t *testing.T) {
 			    } 
 			  ]
 			},
+			"assistActionAiPromptId": 1,
 			"defaultTmId": 1,
 			"defaultGlossaryId": 1,
 			"saveMetaInfoInSource": true,

--- a/crowdin/projects_test.go
+++ b/crowdin/projects_test.go
@@ -1028,6 +1028,15 @@ func TestProjectsService_Add(t *testing.T) {
 				},
 			},
 		},
+		AiPreTranslate: &model.ProjectAiPreTranslate{
+			Enabled: ToPtr(true),
+			AiPrompts: []model.ProjectAiPrompt{
+				{
+					AiPromptID:  1,
+					LanguageIDs: []string{"uk"},
+				},
+			},
+		},
 		DefaultTMID:                   1,
 		DefaultGlossaryID:             1,
 		SaveMetaInfoInSource:          ToPtr(true),
@@ -1134,6 +1143,17 @@ func TestProjectsService_Add(t *testing.T) {
 					"uk"
 				  ]
 				}
+			  ]
+			},
+			"aiPreTranslate": {
+			  "enabled": true,
+			  "aiPrompts": [
+			    {
+				  "aiPromptId": 1,
+				  "languageIds": [
+				    "uk"
+				  ]
+			    } 
 			  ]
 			},
 			"defaultTmId": 1,

--- a/crowdin/projects_test.go
+++ b/crowdin/projects_test.go
@@ -1028,6 +1028,8 @@ func TestProjectsService_Add(t *testing.T) {
 				},
 			},
 		},
+		DefaultTMID:                   1,
+		DefaultGlossaryID:             1,
 		SaveMetaInfoInSource:          ToPtr(true),
 		Type:                          ToPtr(0),
 		SkipUntranslatedFiles:         ToPtr(false),
@@ -1134,6 +1136,8 @@ func TestProjectsService_Add(t *testing.T) {
 				}
 			  ]
 			},
+			"defaultTmId": 1,
+			"defaultGlossaryId": 1,
 			"saveMetaInfoInSource": true,
 			"type": 0,
 			"skipUntranslatedFiles": false,
@@ -1157,6 +1161,8 @@ func TestProjectsService_Add(t *testing.T) {
 				QAChecksIgnorableCategories: projectReq.QAChecksIgnorableCategories,
 				LanguageMapping:             projectReq.LanguageMapping,
 				NotificationSettings:        projectReq.NotificationSettings,
+				DefaultTMID:                 projectReq.DefaultTMID,
+				DefaultGlossaryID:           projectReq.DefaultGlossaryID,
 			},
 		})
 		require.NoError(t, err)
@@ -1178,6 +1184,8 @@ func TestProjectsService_Add(t *testing.T) {
 	assert.Equal(t, projectReq.QAChecksIgnorableCategories, project.QAChecksIgnorableCategories)
 	assert.Equal(t, projectReq.LanguageMapping, project.LanguageMapping)
 	assert.Equal(t, projectReq.NotificationSettings, project.NotificationSettings)
+	assert.Equal(t, projectReq.DefaultTMID, project.DefaultTMID)
+	assert.Equal(t, projectReq.DefaultGlossaryID, project.DefaultGlossaryID)
 
 	assert.NotNil(t, resp)
 }


### PR DESCRIPTION
Resolves #58 

Changes made in this PR:
1. add `DefaultTMID` and `DefaultGlossaryID` in `ProjectsAddRequest`
2. add `DefaultTMID` and `DefaultGlossaryID` in the respective testcases
3. add `ProjectAiPreTranslate` and `ProjectAiPrompt` in `ProjectsAddRequest`
4. add `ProjectAiPreTranslate` and `ProjectAiPrompt` in the respective testcases
5. ~~add `FIXME` and `TODO` comments. Please review.~~ handled through conservations below