### PR TITLE
feat: add support for remove string approvals

### DIFF
--- a/crowdin/string_translations.go
+++ b/crowdin/string_translations.go
@@ -139,10 +139,15 @@ func (s *StringTranslationsService) ListStringTranslations(ctx context.Context, 
 // DeleteStringTranslations deletes string translations by its identifiers.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.translations.deleteMany
-func (s *StringTranslationsService) DeleteStringTranslations(ctx context.Context, projectID, stringID int, languageID string) (
+func (s *StringTranslationsService) DeleteStringTranslations(ctx context.Context, projectID, stringID int, languageID *string) (
 	*Response, error,
 ) {
-	path := fmt.Sprintf("/api/v2/projects/%d/translations?stringId=%d&languageId=%s", projectID, stringID, languageID)
+	path := fmt.Sprintf("/api/v2/projects/%d/translations?stringId=%d", projectID, stringID)
+
+	if languageID != nil {
+		path += fmt.Sprintf("&languageId=%s", *languageID)
+	}
+
 	return s.client.Delete(ctx, path, nil)
 }
 

--- a/crowdin/string_translations.go
+++ b/crowdin/string_translations.go
@@ -60,6 +60,13 @@ func (s *StringTranslationsService) AddApproval(ctx context.Context, projectID, 
 	return res.Data, resp, err
 }
 
+// RemoveStringApprovals removes translation approvals by its string identifier.
+//
+// https://developer.crowdin.com/api/v2/#operation/api.projects.approvals.deleteMany
+func (s *StringTranslationsService) RemoveStringApprovals(ctx context.Context, projectID, stringID int) (*Response, error) {
+	return s.client.Delete(ctx, fmt.Sprintf("/api/v2/projects/%d/approvals?stringId=%d", projectID, stringID), nil)
+}
+
 // RemoveApproval removes a translation approval by its identifier.
 //
 // https://developer.crowdin.com/api/v2/#operation/api.projects.approvals.delete

--- a/crowdin/string_translations_test.go
+++ b/crowdin/string_translations_test.go
@@ -679,7 +679,7 @@ func TestStringTranslationsService_AddTranslation(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
-func TestStringTranslationsService_DeleteStringTranslations(t *testing.T) {
+func TestStringTranslationsService_DeleteStringTranslationsWithLanguageId(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()
 
@@ -691,7 +691,25 @@ func TestStringTranslationsService_DeleteStringTranslations(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := client.StringTranslations.DeleteStringTranslations(context.Background(), 1, 123, "de")
+	languageId := "de"
+	resp, err := client.StringTranslations.DeleteStringTranslations(context.Background(), 1, 123, &languageId)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestStringTranslationsService_DeleteStringTranslationsWithoutLanguageId(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	path := "/api/v2/projects/1/translations"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		testURL(t, r, path+"?stringId=123")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.StringTranslations.DeleteStringTranslations(context.Background(), 1, 123, nil)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }

--- a/crowdin/string_translations_test.go
+++ b/crowdin/string_translations_test.go
@@ -691,8 +691,8 @@ func TestStringTranslationsService_DeleteStringTranslationsWithLanguageId(t *tes
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	languageId := "de"
-	resp, err := client.StringTranslations.DeleteStringTranslations(context.Background(), 1, 123, &languageId)
+	languageID := "de"
+	resp, err := client.StringTranslations.DeleteStringTranslations(context.Background(), 1, 123, &languageID)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }

--- a/crowdin/string_translations_test.go
+++ b/crowdin/string_translations_test.go
@@ -212,6 +212,23 @@ func TestStringTranslationsService_AddApproval(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 }
 
+func TestStringTranslationsService_RemoveStringApprovals(t *testing.T) {
+	client, mux, teardown := setupClient()
+	defer teardown()
+
+	const path = "/api/v2/projects/1/approvals"
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodDelete)
+		testURL(t, r, path+"?stringId=2345")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.StringTranslations.RemoveStringApprovals(context.Background(), 1, 2345)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
 func TestStringTranslationsService_RemoveApproval(t *testing.T) {
 	client, mux, teardown := setupClient()
 	defer teardown()


### PR DESCRIPTION
Resolves issue #68 
- Added support for the remove string approvals API.
- Modified the delete string translation function signature to make languageId optional.