### PR TITLE
fix!: issue with deserializing a response

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ linters:
     - unparam
     - whitespace
     - bidichk
-    - exportloopref
+    - copyloopvar
     - goconst
     - reassign
     - goimports

--- a/crowdin/model/projects.go
+++ b/crowdin/model/projects.go
@@ -9,31 +9,31 @@ import (
 type (
 	// Project represents a Crowdin project.
 	Project struct {
-		ID                   int            `json:"id"`
-		GroupID              int            `json:"groupId,omitempty"`
-		Type                 int            `json:"type"`
-		UserID               int            `json:"userId"`
-		SourceLanguageID     string         `json:"sourceLanguageId"`
-		TargetLanguageIDs    []string       `json:"targetLanguageIds"`
-		LanguageAccessPolicy string         `json:"languageAccessPolicy"`
-		Name                 string         `json:"name"`
-		Cname                string         `json:"cname,omitempty"`
-		Identifier           string         `json:"identifier"`
-		Description          string         `json:"description"`
-		Visibility           string         `json:"visibility"`
-		Logo                 string         `json:"logo"`
-		IsExternal           bool           `json:"isExternal,omitempty"`
-		ExternalType         string         `json:"externalType,omitempty"`
-		WorkflowID           int            `json:"workflowId,omitempty"`
-		HasCrowdsourcing     bool           `json:"hasCrowdsourcing,omitempty"`
-		PublicDownloads      bool           `json:"publicDownloads"`
-		CreatedAt            string         `json:"createdAt"`
-		UpdatedAt            string         `json:"updatedAt"`
-		LastActivity         string         `json:"lastActivity"`
-		SourceLanguage       *Language      `json:"sourceLanguage"`
-		TargetLanguages      []*Language    `json:"targetLanguages"`
-		WebURL               string         `json:"webUrl"`
-		Fields               map[string]any `json:"fields,omitempty"`
+		ID                   int         `json:"id"`
+		GroupID              int         `json:"groupId,omitempty"`
+		Type                 int         `json:"type"`
+		UserID               int         `json:"userId"`
+		SourceLanguageID     string      `json:"sourceLanguageId"`
+		TargetLanguageIDs    []string    `json:"targetLanguageIds"`
+		LanguageAccessPolicy string      `json:"languageAccessPolicy"`
+		Name                 string      `json:"name"`
+		Cname                string      `json:"cname,omitempty"`
+		Identifier           string      `json:"identifier"`
+		Description          string      `json:"description"`
+		Visibility           string      `json:"visibility"`
+		Logo                 string      `json:"logo"`
+		IsExternal           bool        `json:"isExternal,omitempty"`
+		ExternalType         string      `json:"externalType,omitempty"`
+		WorkflowID           int         `json:"workflowId,omitempty"`
+		HasCrowdsourcing     bool        `json:"hasCrowdsourcing,omitempty"`
+		PublicDownloads      bool        `json:"publicDownloads"`
+		CreatedAt            string      `json:"createdAt"`
+		UpdatedAt            string      `json:"updatedAt"`
+		LastActivity         string      `json:"lastActivity"`
+		SourceLanguage       *Language   `json:"sourceLanguage"`
+		TargetLanguages      []*Language `json:"targetLanguages"`
+		WebURL               string      `json:"webUrl"`
+		Fields               any         `json:"fields,omitempty"`
 
 		ClientOrganizationID            int                        `json:"clientOrganizationId,omitempty"`
 		TranslateDuplicates             int                        `json:"translateDuplicates,omitempty"`

--- a/crowdin/model/projects_test.go
+++ b/crowdin/model/projects_test.go
@@ -80,8 +80,18 @@ func TestProjectsAddRequestValidate(t *testing.T) {
 			err:  "sourceLanguageId is required",
 		},
 		{
-			name:  "valid request",
-			req:   &ProjectsAddRequest{Name: "Knowledge Base", SourceLanguageID: "en", TargetLanguageIDs: []string{"fr"}},
+			name: "valid request",
+			req: &ProjectsAddRequest{
+				Name:              "Knowledge Base",
+				SourceLanguageID:  "en",
+				TargetLanguageIDs: []string{"fr"},
+				Fields: map[string]any{
+					"key_1": "value_1",
+					"key_2": 2,
+					"key_3": true,
+					"key_4": []string{"en", "uk"},
+				},
+			},
 			valid: true,
 		},
 	}

--- a/crowdin/model/source_files.go
+++ b/crowdin/model/source_files.go
@@ -126,17 +126,17 @@ func (r *DirectoryAddRequest) Validate() error {
 
 // File represents a project file.
 type File struct {
-	ID          int            `json:"id"`
-	ProjectID   int            `json:"projectId"`
-	BranchID    *int           `json:"branchId,omitempty"`
-	DirectoryID *int           `json:"directoryId,omitempty"`
-	Name        string         `json:"name"`
-	Title       *string        `json:"title,omitempty"`
-	Context     *string        `json:"context,omitempty"`
-	Type        string         `json:"type"`
-	Path        string         `json:"path"`
-	Status      string         `json:"status"`
-	Fields      map[string]any `json:"fields,omitempty"`
+	ID          int     `json:"id"`
+	ProjectID   int     `json:"projectId"`
+	BranchID    *int    `json:"branchId,omitempty"`
+	DirectoryID *int    `json:"directoryId,omitempty"`
+	Name        string  `json:"name"`
+	Title       *string `json:"title,omitempty"`
+	Context     *string `json:"context,omitempty"`
+	Type        string  `json:"type"`
+	Path        string  `json:"path"`
+	Status      string  `json:"status"`
+	Fields      any     `json:"fields,omitempty"`
 
 	RevisionID             int            `json:"revisionId"`
 	Priority               string         `json:"priority"`

--- a/crowdin/model/source_files_test.go
+++ b/crowdin/model/source_files_test.go
@@ -145,8 +145,20 @@ func TestFileAddRequestValidate(t *testing.T) {
 			err:  "branchId and directoryId cannot be used in the same request",
 		},
 		{
-			name:  "valid request",
-			req:   &FileAddRequest{StorageID: 1, Name: "main", BranchID: 1, Title: "Main", Type: "xml"},
+			name: "valid request",
+			req: &FileAddRequest{
+				StorageID: 1,
+				Name:      "main",
+				BranchID:  1,
+				Title:     "Main",
+				Type:      "xml",
+				Fields: map[string]any{
+					"key_1": "value",
+					"key_2": 2,
+					"key_3": false,
+					"key_4": []string{"en", "uk"},
+				},
+			},
 			valid: true,
 		},
 	}

--- a/crowdin/model/source_strings.go
+++ b/crowdin/model/source_strings.go
@@ -8,25 +8,25 @@ import (
 
 // SourceString represents the text units for translation.
 type SourceString struct {
-	ID             int            `json:"id"`
-	ProjectID      int            `json:"projectId"`
-	BranchID       *int           `json:"branchId,omitempty"`
-	Identifier     string         `json:"identifier"`
-	Text           string         `json:"text"`
-	Type           string         `json:"type"`
-	Context        string         `json:"context"`
-	MaxLength      int            `json:"maxLength"`
-	IsHidden       bool           `json:"isHidden"`
-	IsDuplicate    bool           `json:"isDuplicate"`
-	MasterStringID *int           `json:"masterStringId,omitempty"`
-	LabelIDs       []int          `json:"labelIds"`
-	WebURL         string         `json:"webUrl"`
-	CreatedAt      *string        `json:"createdAt,omitempty"`
-	UpdatedAt      *string        `json:"updatedAt,omitempty"`
-	Fields         map[string]any `json:"fields,omitempty"`
-	FileID         *int           `json:"fileId,omitempty"`
-	DirectoryID    *int           `json:"directoryId,omitempty"`
-	Revision       *int           `json:"revision,omitempty"`
+	ID             int     `json:"id"`
+	ProjectID      int     `json:"projectId"`
+	BranchID       *int    `json:"branchId,omitempty"`
+	Identifier     string  `json:"identifier"`
+	Text           string  `json:"text"`
+	Type           string  `json:"type"`
+	Context        string  `json:"context"`
+	MaxLength      int     `json:"maxLength"`
+	IsHidden       bool    `json:"isHidden"`
+	IsDuplicate    bool    `json:"isDuplicate"`
+	MasterStringID *int    `json:"masterStringId,omitempty"`
+	LabelIDs       []int   `json:"labelIds"`
+	WebURL         string  `json:"webUrl"`
+	CreatedAt      *string `json:"createdAt,omitempty"`
+	UpdatedAt      *string `json:"updatedAt,omitempty"`
+	Fields         any     `json:"fields,omitempty"`
+	FileID         *int    `json:"fileId,omitempty"`
+	DirectoryID    *int    `json:"directoryId,omitempty"`
+	Revision       *int    `json:"revision,omitempty"`
 }
 
 // SourceStringsGetResponse describes the response when getting
@@ -156,7 +156,7 @@ type SourceStringsAddRequest struct {
 	// Label Identifiers.
 	LabelIDs []int `json:"labelIds,omitempty"`
 	// Fields (enterprises only).
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]any `json:"fields,omitempty"`
 }
 
 // Validate checks if the add request is valid.

--- a/crowdin/model/source_strings_test.go
+++ b/crowdin/model/source_strings_test.go
@@ -146,7 +146,12 @@ func TestSourceStringsAddRequestValidate(t *testing.T) {
 				Context:    "context",
 				IsHidden:   toPtr(false),
 				MaxLength:  toPtr(10),
-				Fields:     map[string]string{"key": "value"},
+				Fields: map[string]any{
+					"key_1": "value_1",
+					"key_2": 2,
+					"key_3": true,
+					"key_4": []string{"en", "uk"},
+				},
 			},
 			valid: true,
 		},

--- a/crowdin/model/tasks.go
+++ b/crowdin/model/tasks.go
@@ -53,7 +53,7 @@ type (
 		Vendor           string              `json:"vendor,omitempty"`
 		BranchIDs        []int               `json:"branchIds,omitempty"`
 		IsArchived       *bool               `json:"isArchived,omitempty"`
-		Fields           map[string]any      `json:"fields,omitempty"`
+		Fields           any                 `json:"fields,omitempty"`
 	}
 
 	// TaskAssignee represents an assignee of a task.

--- a/crowdin/model/tasks_test.go
+++ b/crowdin/model/tasks_test.go
@@ -631,8 +631,19 @@ func TestEnterpriseTaskCreateFormValidate(t *testing.T) {
 			err:  "one of stringIds or fileIds is required",
 		},
 		{
-			name:  "valid validation",
-			req:   &EnterpriseTaskCreateForm{WorkflowStepID: 1, Title: "French", LanguageID: "en", FileIDs: []int{1}},
+			name: "valid data validation",
+			req: &EnterpriseTaskCreateForm{
+				WorkflowStepID: 1,
+				Title:          "French",
+				LanguageID:     "en",
+				FileIDs:        []int{1},
+				Fields: map[string]any{
+					"key_1": "value",
+					"key_2": 2,
+					"key_3": true,
+					"key_4": []string{"a", "b"},
+				},
+			},
 			valid: true,
 		},
 	}
@@ -681,8 +692,14 @@ func TestEnterpriseVendorTaskCreateFormValidate(t *testing.T) {
 			err:  "one of stringIds or fileIds is required",
 		},
 		{
-			name:  "valid validation",
-			req:   &EnterpriseVendorTaskCreateForm{WorkflowStepID: 1, Title: "French", LanguageID: "en", StringIDs: []int{1}},
+			name: "valid data validation",
+			req: &EnterpriseVendorTaskCreateForm{
+				WorkflowStepID: 1,
+				Title:          "French",
+				LanguageID:     "en",
+				StringIDs:      []int{1},
+				Fields:         nil,
+			},
 			valid: true,
 		},
 	}

--- a/crowdin/model/users.go
+++ b/crowdin/model/users.go
@@ -195,20 +195,20 @@ func (r *ProjectMemberReplaceRequest) Validate() error {
 
 // User represents a user in the system.
 type User struct {
-	ID        int            `json:"id"`
-	Username  string         `json:"username"`
-	Email     string         `json:"email"`
-	FirstName *string        `json:"firstName,omitempty"`
-	LastName  *string        `json:"lastName,omitempty"`
-	FullName  *string        `json:"fullName,omitempty"`
-	Status    *string        `json:"status,omitempty"` // Enum: active, pending, blocked
-	AvatarURL string         `json:"avatarUrl"`
-	CreatedAt string         `json:"createdAt"`
-	LastSeen  string         `json:"lastSeen,omitempty"`
-	TwoFactor string         `json:"twoFactor"` // Enum: enabled, disabled
-	IsAdmin   *bool          `json:"isAdmin,omitempty"`
-	Timezone  string         `json:"timezone,omitempty"`
-	Fields    map[string]any `json:"fields,omitempty"`
+	ID        int     `json:"id"`
+	Username  string  `json:"username"`
+	Email     string  `json:"email"`
+	FirstName *string `json:"firstName,omitempty"`
+	LastName  *string `json:"lastName,omitempty"`
+	FullName  *string `json:"fullName,omitempty"`
+	Status    *string `json:"status,omitempty"` // Enum: active, pending, blocked
+	AvatarURL string  `json:"avatarUrl"`
+	CreatedAt string  `json:"createdAt"`
+	LastSeen  string  `json:"lastSeen,omitempty"`
+	TwoFactor string  `json:"twoFactor"` // Enum: enabled, disabled
+	IsAdmin   *bool   `json:"isAdmin,omitempty"`
+	Timezone  string  `json:"timezone,omitempty"`
+	Fields    any     `json:"fields,omitempty"`
 }
 
 // ShortUser is a simplified version of the User model.

--- a/crowdin/projects_test.go
+++ b/crowdin/projects_test.go
@@ -799,12 +799,31 @@ func TestProjectsService_List(t *testing.T) {
 			"data": [
 				{
 					"data": {
-						"id": 1
+						"id": 1,
+						"fields": {
+							"key_1": "value",
+							"key_2": 2,
+							"key_3": true,
+							"key_4": ["en", "uk"]
+						}
 					}
 				},
 				{
 					"data": {
-						"id": 2
+						"id": 2,
+						"fields": []
+					}
+				},
+				{
+					"data": {
+						"id": 3,
+						"fields": {}
+					}
+				},
+				{
+					"data": {
+						"id": 4,
+						"fields": null
 					}
 				}
 			],
@@ -819,10 +838,17 @@ func TestProjectsService_List(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedProjects := []*model.Project{
-		{ID: 1},
-		{ID: 2},
+		{ID: 1, Fields: map[string]any{
+			"key_1": "value",
+			"key_2": float64(2),
+			"key_3": true,
+			"key_4": []any{"en", "uk"},
+		}},
+		{ID: 2, Fields: []any{}},
+		{ID: 3, Fields: map[string]any{}},
+		{ID: 4, Fields: nil},
 	}
-	assert.Len(t, projects, 2)
+	assert.Len(t, projects, 4)
 	assert.Equal(t, expectedProjects, projects)
 
 	expectedPagination := model.Pagination{Offset: 10, Limit: 25}
@@ -1047,6 +1073,12 @@ func TestProjectsService_Add(t *testing.T) {
 		InContextProcessHiddenStrings: ToPtr(true),
 		InContextPseudoLanguageID:     "de",
 		TMContextType:                 "segmentContext",
+		Fields: map[string]any{
+			"key_1": "value_1",
+			"key_2": 2,
+			"key_3": true,
+			"key_4": []string{"en", "es"},
+		},
 	}
 
 	mux.HandleFunc("/api/v2/projects", func(w http.ResponseWriter, r *http.Request) {
@@ -1165,7 +1197,13 @@ func TestProjectsService_Add(t *testing.T) {
 			"skipUntranslatedFiles": false,
 			"inContext": true,
 			"inContextProcessHiddenStrings": true,
-			"inContextPseudoLanguageId": "de"
+			"inContextPseudoLanguageId": "de",
+			"fields": {
+			  "key_1": "value_1",
+			  "key_2": 2,
+			  "key_3": true,
+			  "key_4": ["en", "es"]
+			}
 		}`
 		testJSONBody(t, r, expectedReqBody)
 

--- a/crowdin/source_files_test.go
+++ b/crowdin/source_files_test.go
@@ -358,7 +358,10 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 						"path": "/directory1/directory2/filename.extension",
 						"status": "active",
 						"fields": {
-							"fieldSlug": "fieldValue"
+							"key_1": "value_1",
+							"key_2": 2,
+							"key_3": true,
+							"key_4": ["en", "uk"]
 						}
 					}
 				},
@@ -374,9 +377,22 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 						"type": "xliff",
 						"path": "/directory1/directory2/filename.extension",
 						"status": "active",
-						"fields": {
-							"fieldSlug": "fieldValue"
-						}
+						"fields": []
+					}
+				},
+				{
+					"data": {
+						"id": 46,
+						"projectId": 2,
+						"branchId": 34,
+						"directoryId": 4,
+						"name": "umbrella_app.xliff",
+						"title": "source_app_info",
+						"context": "Context for translators",
+						"type": "xliff",
+						"path": "/directory1/directory2/filename.extension",
+						"status": "active",
+						"fields": {}
 					}
 				}
 			],
@@ -402,7 +418,12 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 			Type:        "xliff",
 			Path:        "/directory1/directory2/filename.extension",
 			Status:      "active",
-			Fields:      map[string]any{"fieldSlug": "fieldValue"},
+			Fields: map[string]any{
+				"key_1": "value_1",
+				"key_2": float64(2),
+				"key_3": true,
+				"key_4": []interface{}{"en", "uk"},
+			},
 		},
 		{
 			ID:          45,
@@ -415,7 +436,20 @@ func TestSourceFilesService_ListFiles(t *testing.T) {
 			Type:        "xliff",
 			Path:        "/directory1/directory2/filename.extension",
 			Status:      "active",
-			Fields:      map[string]any{"fieldSlug": "fieldValue"},
+			Fields:      []any{},
+		},
+		{
+			ID:          46,
+			ProjectID:   2,
+			BranchID:    ToPtr(34),
+			DirectoryID: ToPtr(4),
+			Name:        "umbrella_app.xliff",
+			Title:       ToPtr("source_app_info"),
+			Context:     ToPtr("Context for translators"),
+			Type:        "xliff",
+			Path:        "/directory1/directory2/filename.extension",
+			Status:      "active",
+			Fields:      map[string]any{},
 		},
 	}
 	assert.Equal(t, expected, files)
@@ -577,7 +611,10 @@ func TestSourceFilesService_AddFile(t *testing.T) {
 			"excludedTargetLanguages": ["en", "es", "pl"],
 			"attachLabelIds": [1],
 			"fields": {
-				"fieldSlug": "fieldValue"
+				"key_1": "value_1",
+				"key_2": 2,
+				"key_3": true,
+				"key_4": ["en", "uk"]
 			}
 		}`
 		testJSONBody(t, r, expectedReqBody)
@@ -615,7 +652,12 @@ func TestSourceFilesService_AddFile(t *testing.T) {
 		},
 		ExcludedTargetLanguages: []string{"en", "es", "pl"},
 		AttachLabelIDs:          []int{1},
-		Fields:                  map[string]any{"fieldSlug": "fieldValue"},
+		Fields: map[string]any{
+			"key_1": "value_1",
+			"key_2": 2,
+			"key_3": true,
+			"key_4": []interface{}{"en", "uk"},
+		},
 	}
 	file, resp, err := client.SourceFiles.AddFile(context.Background(), 1, req)
 	require.NoError(t, err)

--- a/crowdin/source_strings_test.go
+++ b/crowdin/source_strings_test.go
@@ -42,13 +42,34 @@ func TestSourceStringsService_List(t *testing.T) {
 						"createdAt": "2023-09-20T12:43:57+00:00",
 						"updatedAt": "2023-09-20T13:24:01+00:00",
 						"fields": {
-							"fieldSlug": "fieldValue"
+							"key_1": "value_1",
+							"key_2": 2,
+							"key_3": true,
+							"key_4": ["en", "uk"]
 						},
 						"fileId": 48,
 						"directoryId": 13,
 						"revision": 1
 					}
-			  	}
+				},
+				{
+					"data": {
+						"id": 2815,
+						"fields": []
+					}
+				},
+				{
+					"data": {
+						"id": 2816,
+						"fields": {}
+					}
+				},
+				{
+					"data": {
+						"id": 2817,
+						"fields": null
+					}
+				}
 			],
 			"pagination": {
 				"offset": 10,
@@ -79,10 +100,27 @@ func TestSourceStringsService_List(t *testing.T) {
 			WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 			CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 			UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),
-			Fields:         map[string]interface{}{"fieldSlug": "fieldValue"},
-			FileID:         ToPtr(48),
-			DirectoryID:    ToPtr(13),
-			Revision:       ToPtr(1),
+			Fields: map[string]any{
+				"key_1": "value_1",
+				"key_2": float64(2),
+				"key_3": true,
+				"key_4": []any{"en", "uk"},
+			},
+			FileID:      ToPtr(48),
+			DirectoryID: ToPtr(13),
+			Revision:    ToPtr(1),
+		},
+		{
+			ID:     2815,
+			Fields: []any{},
+		},
+		{
+			ID:     2816,
+			Fields: map[string]any{},
+		},
+		{
+			ID:     2817,
+			Fields: nil,
 		},
 	}
 	if !reflect.DeepEqual(sourceStrings, want) {
@@ -196,9 +234,7 @@ func TestSourceStringsService_Get(t *testing.T) {
 				"webUrl": "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 				"createdAt": "2023-09-20T12:43:57+00:00",
 				"updatedAt": "2023-09-20T13:24:01+00:00",
-				"fields": {
-					"fieldSlug": "fieldValue"
-				},
+				"fields": [],
 				"fileId": 48,
 				"directoryId": 13,
 				"revision": 1
@@ -227,7 +263,7 @@ func TestSourceStringsService_Get(t *testing.T) {
 		WebURL:         "https://example.crowdin.com/editor/1/all/en-pl?filter=basic&value=0&view=comfortable#2",
 		CreatedAt:      ToPtr("2023-09-20T12:43:57+00:00"),
 		UpdatedAt:      ToPtr("2023-09-20T13:24:01+00:00"),
-		Fields:         map[string]interface{}{"fieldSlug": "fieldValue"},
+		Fields:         []any{},
 		FileID:         ToPtr(48),
 		DirectoryID:    ToPtr(13),
 		Revision:       ToPtr(1),
@@ -287,16 +323,28 @@ func TestSourceStringsService_Add(t *testing.T) {
 		IsHidden:   ToPtr(false),
 		MaxLength:  ToPtr(35),
 		LabelIDs:   []int{3, 5, 7},
-		Fields: map[string]string{
+		Fields: map[string]any{
 			"fieldSlug": "fieldValue",
-			"foo":       "bar",
+			"foo":       true,
 		},
 	}
 
 	mux.HandleFunc(fmt.Sprintf("/api/v2/projects/%d/strings", projectID), func(w http.ResponseWriter, r *http.Request) {
 		testURL(t, r, fmt.Sprintf("/api/v2/projects/%d/strings", projectID))
 		testMethod(t, r, http.MethodPost)
-		testBody(t, r, `{"text":"Not all videos are shown to users.","fileId":48,"identifier":"name","context":"shown on main page","isHidden":false,"maxLength":35,"labelIds":[3,5,7],"fields":{"fieldSlug":"fieldValue","foo":"bar"}}`+"\n")
+		testJSONBody(t, r, `{
+			"text": "Not all videos are shown to users.",
+			"fileId": 48,
+			"identifier": "name",
+			"context": "shown on main page",
+			"isHidden": false,
+			"maxLength": 35,
+			"labelIds": [3,5,7],
+			"fields": {
+				"fieldSlug": "fieldValue",
+				"foo": true
+			}
+		}`)
 
 		fmt.Fprint(w, `{
 			"data": {

--- a/crowdin/string_comments_test.go
+++ b/crowdin/string_comments_test.go
@@ -353,7 +353,6 @@ func TestStringCommentsService_Delete(t *testing.T) {
 		testURL(t, r, path)
 
 		w.WriteHeader(http.StatusNoContent)
-		w.WriteHeader(http.StatusNoContent)
 	})
 
 	resp, err := client.StringComments.Delete(context.Background(), 1, 2)

--- a/crowdin/tasks_test.go
+++ b/crowdin/tasks_test.go
@@ -111,7 +111,10 @@ func TestTasksService_Get(t *testing.T) {
 				"fileIds": [24,25,38],
 				"branchIds": [24,25,38],
 				"fields": {
-					"fieldSlug": "fieldValue"
+					"some-field-1": "some value 1",
+					"some-field-2": 12,
+					"some-field-3": true,
+					"some-field-4": ["en","uk"]
 				}
 			}
 		}`)
@@ -206,7 +209,10 @@ func TestTasksService_Get(t *testing.T) {
 		FileIDs:         []int{24, 25, 38},
 		BranchIDs:       []int{24, 25, 38},
 		Fields: map[string]any{
-			"fieldSlug": "fieldValue",
+			"some-field-1": "some value 1",
+			"some-field-2": float64(12),
+			"some-field-3": true,
+			"some-field-4": []any{"en", "uk"},
 		},
 	}
 	assert.Equal(t, expected, task)
@@ -260,12 +266,31 @@ func TestTasksService_List(t *testing.T) {
 					"data": [
 						{
 							"data": {
-								"id": 2
+								"id": 2,
+								"fields": {
+									"some-field-1": "some value 1",
+									"some-field-2": 12,
+									"some-field-3": true,
+									"some-field-4": ["en","uk"]
+								}
 							}
 						},
 						{
 							"data": {
-								"id": 4
+								"id": 4,
+								"fields": []
+							}
+						},
+						{
+							"data": {
+								"id": 6,
+								"fields": {}
+							}
+						},
+						{
+							"data": {
+								"id": 8,
+								"fields": null
 							}
 						}
 					],
@@ -279,7 +304,19 @@ func TestTasksService_List(t *testing.T) {
 			tasks, resp, err := client.Tasks.List(context.Background(), projectID, tt.options)
 			require.NoError(t, err)
 
-			expected := []*model.Task{{ID: 2}, {ID: 4}}
+			expected := []*model.Task{
+				{
+					ID: 2,
+					Fields: map[string]any{
+						"some-field-1": "some value 1",
+						"some-field-2": float64(12),
+						"some-field-3": true,
+						"some-field-4": []any{"en", "uk"},
+					}},
+				{ID: 4, Fields: []any{}},
+				{ID: 6, Fields: map[string]any{}},
+				{ID: 8, Fields: nil},
+			}
 			assert.Equal(t, expected, tasks)
 
 			assert.Equal(t, 10, resp.Pagination.Offset)

--- a/crowdin/users_test.go
+++ b/crowdin/users_test.go
@@ -1031,17 +1031,43 @@ func TestUsersService_List(t *testing.T) {
 					"data": [
 						{
 							"data": {
-								"id": 12
+								"id": 10,
+								"fields": null
 							}
 						},
 						{
 							"data": {
-								"id": 14
+								"id": 12,
+								"fields": []
 							}
 						},
 						{
 							"data": {
-								"id": 16
+								"id": 14,
+								"fields": {}
+							}
+						},
+						{
+							"data": {
+								"id": 16,
+								"fields": {
+									"foo": "bar"
+								}
+							}
+						},
+						{
+							"data": {
+								"id": 18,
+								"fields": {
+									"key_1": "value",
+									"key_2": 2,
+									"key_3": true,
+									"key_4": ["en", "uk"],
+									"key_5": {
+										"foo": "bar"
+									},
+									"key_6": null
+								}
 							}
 						}
 					],
@@ -1055,9 +1081,25 @@ func TestUsersService_List(t *testing.T) {
 			users, resp, err := client.Users.List(context.Background(), tt.opts)
 			require.NoError(t, err)
 
-			expected := []*model.User{{ID: 12}, {ID: 14}, {ID: 16}}
+			expected := []*model.User{
+				{ID: 10, Fields: nil},
+				{ID: 12, Fields: []any{}},
+				{ID: 14, Fields: map[string]any{}},
+				{ID: 16, Fields: map[string]any{"foo": "bar"}},
+				{
+					ID: 18,
+					Fields: map[string]any{
+						"key_1": "value",
+						"key_2": float64(2),
+						"key_3": true,
+						"key_4": []any{"en", "uk"},
+						"key_5": map[string]any{"foo": "bar"},
+						"key_6": nil,
+					},
+				},
+			}
 			assert.Equal(t, expected, users)
-			assert.Len(t, users, 3)
+			assert.Len(t, users, 5)
 
 			assert.Equal(t, 10, resp.Pagination.Offset)
 			assert.Equal(t, 25, resp.Pagination.Limit)
@@ -1096,7 +1138,8 @@ func TestUsersService_GetAuthenticated(t *testing.T) {
 					"createdAt": "2023-07-11T07:40:22+00:00",
 					"lastSeen": "2023-10-23T11:44:02+00:00",
 					"twoFactor": "enabled",
-					"timezone": "Europe/Kyiv"
+					"timezone": "Europe/Kyiv",
+					"fields": []
 				}
 			}`,
 			expect: &model.User{
@@ -1109,6 +1152,7 @@ func TestUsersService_GetAuthenticated(t *testing.T) {
 				LastSeen:  "2023-10-23T11:44:02+00:00",
 				TwoFactor: "enabled",
 				Timezone:  "Europe/Kyiv",
+				Fields:    []any{},
 			},
 		},
 		{


### PR DESCRIPTION
- `Fields` type in the `Project`, `SourceString`, `File`, `Task`, and `User` structs has been changed from `map[string]any` to `any`. This change may affect code that relies on the previous type.
- Update .golangci.yml to replace the deprecated 'exportloopref' linter with 'copyloopvar'.