### PR TITLE
fix!: issues with deserialising a response

### DIFF
--- a/crowdin/model/tasks.go
+++ b/crowdin/model/tasks.go
@@ -937,9 +937,9 @@ type (
 	// TaskSettingsTemplateLanguage represents the language settings of a
 	// task settings template.
 	TaskSettingsTemplateLanguage struct {
-		LanguageID string `json:"languageId"`
-		UserIDs    []int  `json:"userIds"`
-		TeamIDs    []int  `json:"teamIds,omitempty"`
+		LanguageID string   `json:"languageId"`
+		UserIDs    []UserID `json:"userIds"`
+		TeamIDs    []int    `json:"teamIds,omitempty"`
 	}
 )
 

--- a/crowdin/model/tasks_test.go
+++ b/crowdin/model/tasks_test.go
@@ -111,7 +111,13 @@ func TestTaskSettingsTemplateAddRequestValidate(t *testing.T) {
 				Name: "Default template",
 				Config: TaskSettingsTemplateConfig{
 					Languages: []TaskSettingsTemplateLanguage{
-						{LanguageID: "uk", UserIDs: []int{1, 2}, TeamIDs: []int{3, 4}}}},
+						{
+							LanguageID: "uk",
+							UserIDs:    []UserID{1, 2},
+							TeamIDs:    []int{3, 4},
+						},
+					},
+				},
 			},
 			valid: true,
 		},

--- a/crowdin/model/users_test.go
+++ b/crowdin/model/users_test.go
@@ -204,9 +204,9 @@ func TestLanguagesAccessUnmarshalJSON(t *testing.T) {
 		err      string
 	}{
 		{
-			name:     "invalid data",
-			data:     []byte(`"invalid json"`),
-			err:      "json: cannot unmarshal string into Go value of type map[string]*model.LanguageAccess",
+			name: "invalid data",
+			data: []byte(`"invalid json"`),
+			err:  "json: cannot unmarshal string into Go value of type map[string]*model.LanguageAccess",
 		},
 		{
 			name: "valid data",
@@ -253,14 +253,14 @@ func TestUserIDUnmarshalJSON(t *testing.T) {
 		err      string
 	}{
 		{
-			name:     "invalid data",
-			data:     []byte(`"invalid json"`),
-			err:      "invalid userId value: invalid json",
+			name: "invalid data",
+			data: []byte(`"invalid json"`),
+			err:  "invalid userId value: invalid json",
 		},
 		{
-			name:     "invalid data",
-			data:     []byte(`[]`),
-			err:      "invalid userId value: []",
+			name: "invalid data",
+			data: []byte(`[]`),
+			err:  "invalid userId value: []",
 		},
 		{
 			name:     "valid data (int)",

--- a/crowdin/model/users_test.go
+++ b/crowdin/model/users_test.go
@@ -195,3 +195,97 @@ func TestInviteUserRequestValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestLanguagesAccessUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected LanguagesAccess
+		err      string
+	}{
+		{
+			name:     "invalid data",
+			data:     []byte(`"invalid json"`),
+			err:      "json: cannot unmarshal string into Go value of type map[string]*model.LanguageAccess",
+		},
+		{
+			name: "valid data",
+			data: []byte(`{"en":{"allContent":true,"workflowStepIds":[882]}}`),
+			expected: map[string]*LanguageAccess{
+				"en": {
+					AllContent:      toPtr(true),
+					WorkflowStepIDs: []int{882},
+				},
+			},
+		},
+		{
+			name:     "valid data with empty array",
+			data:     []byte(`[]`),
+			expected: LanguagesAccess{},
+		},
+		{
+			name:     "valid data with empty object",
+			data:     []byte(`{}`),
+			expected: LanguagesAccess{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actual LanguagesAccess
+			err := actual.UnmarshalJSON(tt.data)
+
+			if len(tt.err) > 0 {
+				assert.EqualError(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUserIDUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected UserID
+		err      string
+	}{
+		{
+			name:     "invalid data",
+			data:     []byte(`"invalid json"`),
+			err:      "invalid userId value: invalid json",
+		},
+		{
+			name:     "invalid data",
+			data:     []byte(`[]`),
+			err:      "invalid userId value: []",
+		},
+		{
+			name:     "valid data (int)",
+			data:     []byte(`1`),
+			expected: 1,
+		},
+		{
+			name:     "valid data (string num)",
+			data:     []byte(`"2"`),
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actual UserID
+			err := actual.UnmarshalJSON(tt.data)
+
+			if len(tt.err) > 0 {
+				assert.EqualError(t, err, tt.err)
+				assert.Equal(t, tt.expected, actual)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}

--- a/crowdin/tasks_test.go
+++ b/crowdin/tasks_test.go
@@ -815,7 +815,7 @@ func TestTasksService_GetSettingsTepmlate(t *testing.T) {
 					"languages": [
 						{
 							"languageId": "uk",
-							"userIds": [1]
+							"userIds": [1, "2"]
 						}
 					]
 				},
@@ -836,7 +836,7 @@ func TestTasksService_GetSettingsTepmlate(t *testing.T) {
 			Languages: []model.TaskSettingsTemplateLanguage{
 				{
 					LanguageID: "uk",
-					UserIDs:    []int{1},
+					UserIDs:    []model.UserID{1, 2},
 				},
 			},
 		},
@@ -900,6 +900,23 @@ func TestTasksService_ListSettingsTepmlates(t *testing.T) {
 								"createdAt": "2023-09-23T11:26:54+00:00",
 								"updatedAt": "2023-09-23T11:26:54+00:00"
 							}
+						},
+						{
+							"data": {
+								"id": 2,
+								"name": "Test template",
+								"config": {
+									"languages": [
+										{
+											"languageId": "uk",
+											"userIds": ["1", "2", 3],
+											"teamIds": [2]
+										}
+									]
+								},
+								"createdAt": "2023-09-23T11:26:54+00:00",
+								"updatedAt": "2023-09-23T11:26:54+00:00"
+							}
 						}
 					],
 					"pagination": {
@@ -920,7 +937,22 @@ func TestTasksService_ListSettingsTepmlates(t *testing.T) {
 						Languages: []model.TaskSettingsTemplateLanguage{
 							{
 								LanguageID: "uk",
-								UserIDs:    []int{1},
+								UserIDs:    []model.UserID{1},
+								TeamIDs:    []int{2},
+							},
+						},
+					},
+					CreatedAt: "2023-09-23T11:26:54+00:00",
+					UpdatedAt: "2023-09-23T11:26:54+00:00",
+				},
+				{
+					ID:   2,
+					Name: "Test template",
+					Config: model.TaskSettingsTemplateConfig{
+						Languages: []model.TaskSettingsTemplateLanguage{
+							{
+								LanguageID: "uk",
+								UserIDs:    []model.UserID{1, 2, 3},
 								TeamIDs:    []int{2},
 							},
 						},
@@ -985,7 +1017,7 @@ func TestTasksService_AddSettingsTepmlates(t *testing.T) {
 			Languages: []model.TaskSettingsTemplateLanguage{
 				{
 					LanguageID: "uk",
-					UserIDs:    []int{1},
+					UserIDs:    []model.UserID{1},
 				},
 			},
 		},
@@ -1001,7 +1033,7 @@ func TestTasksService_AddSettingsTepmlates(t *testing.T) {
 			Languages: []model.TaskSettingsTemplateLanguage{
 				{
 					LanguageID: "uk",
-					UserIDs:    []int{1},
+					UserIDs:    []model.UserID{1},
 				},
 			},
 		},
@@ -1029,7 +1061,7 @@ func TestTasksService_EditSettingsTepmlates(t *testing.T) {
 					"languages": [
 						{
 							"languageId": "uk",
-							"userIds": [1]
+							"userIds": ["1"]
 						}
 					]
 				},
@@ -1057,7 +1089,7 @@ func TestTasksService_EditSettingsTepmlates(t *testing.T) {
 			Languages: []model.TaskSettingsTemplateLanguage{
 				{
 					LanguageID: "uk",
-					UserIDs:    []int{1},
+					UserIDs:    []model.UserID{1},
 				},
 			},
 		},

--- a/crowdin/users_test.go
+++ b/crowdin/users_test.go
@@ -54,6 +54,13 @@ func TestUsersService_GetProjectMember(t *testing.T) {
 						}
 					},
 					{
+						"name": "proofreader",
+						"permissions": {
+							"allLanguages": true,
+							"languagesAccess": []
+						}
+					},
+					{
 						"name": "language_coordinator",
 						"permissions": {
 							"allLanguages": false,
@@ -102,6 +109,13 @@ func TestUsersService_GetProjectMember(t *testing.T) {
 							AllContent: ToPtr(true),
 						},
 					},
+				},
+			},
+			{
+				Name: "proofreader",
+				Permissions: &model.RolePermissions{
+					AllLanguages:    ToPtr(true),
+					LanguagesAccess: map[string]*model.LanguageAccess{},
 				},
 			},
 			{
@@ -179,6 +193,13 @@ func TestUsersService_GetProjectMember_EnterpriseAPI(t *testing.T) {
 						}
 					},
 					{
+						"name": "proofreader",
+						"permissions": {
+							"allLanguages": false,
+							"languagesAccess": []
+						}
+					},
+					{
 						"name": "language_coordinator",
 						"permissions": {
 							"allLanguages": false,
@@ -239,6 +260,13 @@ func TestUsersService_GetProjectMember_EnterpriseAPI(t *testing.T) {
 				Name: "proofreader",
 				Permissions: &model.RolePermissions{
 					AllLanguages:    ToPtr(true),
+					LanguagesAccess: map[string]*model.LanguageAccess{},
+				},
+			},
+			{
+				Name: "proofreader",
+				Permissions: &model.RolePermissions{
+					AllLanguages:    ToPtr(false),
 					LanguagesAccess: map[string]*model.LanguageAccess{},
 				},
 			},
@@ -459,7 +487,7 @@ func TestUsersService_AddProjectMember(t *testing.T) {
 								"name": "proofreader",
 								"permissions": {
 									"allLanguages": true,
-									"languagesAccess": {}
+									"languagesAccess": []
 								}
 							},
 							{


### PR DESCRIPTION
- Using a custom type for `UserIDs` (`TaskSettingsTemplateLanguage`) for handling  both int and string numeric formats. This change may affect code that relies on the previous type.

- Adding a custom `UnmarshalJSON` method to handle unmarshaling of `LanguagesAccess` from both empty arrays and maps.