### PR TITLE
feat: add styleGuideIds to apply pre-translation requests

### DIFF
--- a/crowdin/model/translations.go
+++ b/crowdin/model/translations.go
@@ -91,6 +91,8 @@ type PreTranslationRequest struct {
 	LanguageIDs []string `json:"languageIds"`
 	// Files array that should be translated.
 	FileIDs []int `json:"fileIds"`
+	// Style Guide Identifiers used during pre-translation.
+	StyleGuideIDs []int `json:"styleGuideIds,omitempty"`
 	// Defines pre-translation method. Enum: "tm", "mt", "ai". Default: "tm".
 	//  - tm – pre-translation via Translation Memory.
 	//  - mt – pre-translation via Machine Translation. "mt" should be used with `engineId` parameter.

--- a/crowdin/translations_test.go
+++ b/crowdin/translations_test.go
@@ -323,6 +323,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 		expectedReqBody := `{
 			"languageIds": ["uk"],
 			"fileIds": [742],
+			"styleGuideIds": [1, 2],
 			"method": "tm",
 			"engineId": 1,
 			"autoApproveOption": "all",
@@ -365,6 +366,7 @@ func TestTranslationsService_ApplyPreTranslation(t *testing.T) {
 	req := &model.PreTranslationRequest{
 		LanguageIDs:                   []string{"uk"},
 		FileIDs:                       []int{742},
+		StyleGuideIDs:                 []int{1, 2},
 		Method:                        "tm",
 		EngineID:                      1,
 		AutoApproveOption:             "all",


### PR DESCRIPTION
Closes #139.

## Summary

- add `StyleGuideIDs` to `model.PreTranslationRequest`
- serialize the field as optional `styleGuideIds`
- cover the field in the Apply Pre-Translation request-body test

## Verification

- `go test ./crowdin/model -run TestPreTranslationRequestValidate`
- `go test ./crowdin -run TestTranslationsService_ApplyPreTranslation`
- `go test ./...`
- `git diff --check`
